### PR TITLE
Enable PDF/Excel admin reports and navigation links

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,6 @@ python-dotenv==1.0.0
 requests==2.31.0
 pandas==2.1.4
 openpyxl==3.1.5
+# Library for generating PDF reports
+reportlab==4.2.0
 # numpy==1.24.3  # Commented out as we're using numpy 2.3.0 which is compatible with Python 3.12

--- a/templates/admin/admin_administrativo_dashboard.html
+++ b/templates/admin/admin_administrativo_dashboard.html
@@ -340,18 +340,25 @@
                 <p class="text-muted">Selecione uma das opções abaixo para gerenciar o sistema</p>
             </div>
             <div class="row justify-content-center">
-                <div class="col-lg-5 col-md-6 mb-3">
+                <div class="col-lg-4 col-md-6 mb-3">
                     <a href="{{ url_for('admin.pagina_corrigir_descarga') }}" class="action-btn w-100 text-center" style="display: block; padding: 2rem;">
                         <i class="fas fa-tools fa-2x mb-2"></i>
                         <h5 class="mb-2">Corrigir Descargas</h5>
                         <small>Ajustar posições e dados de containers de todas as unidades</small>
                     </a>
                 </div>
-                <div class="col-lg-5 col-md-6 mb-3">
+                <div class="col-lg-4 col-md-6 mb-3">
                     <a href="{{ url_for('admin.historico_containers') }}" class="action-btn secondary w-100 text-center" style="display: flex; flex-direction: column; align-items: center; justify-content: center; padding: 2rem; color: white !important; text-decoration: none;">
                         <i class="fas fa-history fa-2x mb-2"></i>
                         <h5 class="mb-2">Histórico Completo</h5>
                         <small>Visualizar histórico completo com filtros avançados</small>
+                    </a>
+                </div>
+                <div class="col-lg-4 col-md-6 mb-3">
+                    <a href="{{ url_for('admin.relatorios') }}" class="action-btn w-100 text-center" style="display: block; padding: 2rem;">
+                        <i class="fas fa-chart-bar fa-2x mb-2"></i>
+                        <h5 class="mb-2">Relatórios</h5>
+                        <small>Baixar relatórios em PDF ou Excel</small>
                     </a>
                 </div>
             </div>

--- a/templates/admin/base.html
+++ b/templates/admin/base.html
@@ -71,6 +71,11 @@
                                 <i class="fas fa-history me-2"></i> Histórico Completo
                             </a>
                         </li>
+                        <li class="nav-item">
+                            <a class="nav-link text-white {% if 'relatorios' in request.path %}active{% endif %}" href="{{ url_for('admin.relatorios') }}">
+                                <i class="fas fa-file-alt me-2"></i> Relatórios
+                            </a>
+                        </li>
                         {% endif %}
                         
                         <!-- Item visível para ambos os tipos de admin -->

--- a/templates/admin/relatorios.html
+++ b/templates/admin/relatorios.html
@@ -69,6 +69,36 @@
 </div>
 
 <div class="container-fluid">
+    <!-- Download de Relatórios -->
+    <div class="card mb-4">
+        <div class="card-header bg-secondary text-white">
+            <h5 class="mb-0"><i class="fas fa-download me-2"></i>Baixar Relatório de Containers</h5>
+        </div>
+        <div class="card-body">
+            <div class="row g-3">
+                <div class="col-md-4">
+                    <label class="form-label">Unidade</label>
+                    <select id="relatorio-unidade" class="form-select">
+                        <option value="">Todas</option>
+                        {% for unidade, _ in ocupacao_unidades %}
+                        <option value="{{ unidade }}">{{ unidade }}</option>
+                        {% endfor %}
+                    </select>
+                </div>
+                <div class="col-md-4 align-self-end">
+                    <button type="button" class="btn btn-success w-100" onclick="baixarRelatorio('xlsx')">
+                        <i class="fas fa-file-excel me-2"></i>Excel
+                    </button>
+                </div>
+                <div class="col-md-4 align-self-end">
+                    <button type="button" class="btn btn-danger w-100" onclick="baixarRelatorio('pdf')">
+                        <i class="fas fa-file-pdf me-2"></i>PDF
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+
     <!-- Estatísticas Gerais -->
     <div class="row mb-4">
         <div class="col-md-4">
@@ -271,7 +301,7 @@
                             </a>
                         </div>
                         <div class="col-md-3">
-                            <a href="{{ url_for('admin.corrigir_descarga') }}" class="btn btn-success btn-lg w-100 mb-2">
+                            <a href="{{ url_for('admin.pagina_corrigir_descarga') }}" class="btn btn-success btn-lg w-100 mb-2">
                                 <i class="fas fa-edit me-2"></i>
                                 Corrigir Descargas
                             </a>
@@ -329,5 +359,15 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     }
 });
+
+function baixarRelatorio(formato) {
+    const unidade = document.getElementById('relatorio-unidade').value;
+    const params = new URLSearchParams();
+    if (unidade) {
+        params.append('unidade', unidade);
+    }
+    params.append('formato', formato);
+    window.open(`/admin/api/download-relatorio-containers?${params.toString()}`, '_blank');
+}
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add reportlab dependency for generating PDF files
- expose reports link in admin sidebar/dashboard and allow downloads in PDF or Excel
- support CSV, Excel, and PDF formats in container report endpoint

## Testing
- `pip install -r requirements.txt`
- `pytest` *(fails: ModuleNotFoundError: No module named 'posicoes_suzano')*


------
https://chatgpt.com/codex/tasks/task_e_6891e8edf3d8832287c24c54d31bea09