### PR TITLE
Display logged in user on vistoriador dashboard

### DIFF
--- a/templates/auth/dashboard_vistoriador.html
+++ b/templates/auth/dashboard_vistoriador.html
@@ -74,7 +74,7 @@
       }
 
       .user-info {
-        color: rgba(255, 255, 255, 0.9);
+        color: #ffffff;
         font-weight: 500;
       }
 
@@ -661,7 +661,8 @@
                 <div class="user-actions">
                   <span class="user-info me-3">
                     <i class="fas fa-user-circle me-1"></i>
-                    Vistoriador | {{ unidade }}
+                    Bem-vindo(a), {{ user.nome if user.nome else user.username }}!<br />
+                    Nível de acesso: Vistoriador {{ unidade }}
                   </span>
                   <button class="btn btn-logout" onclick="confirmarLogout()">
                     <i class="fas fa-sign-out-alt me-1"></i>
@@ -677,10 +678,8 @@
                 <h4 class="welcome-title">
                   Bem-vindo(a), {{ user.nome if user.nome else user.username }}!
                 </h4>
-                <p class="text-muted mb-3">
-                  Nível de acesso:
-                  <span class="badge bg-warning">Vistoriador</span>
-                  <span class="badge bg-info">{{ unidade }}</span>
+                <p class="mb-3 text-dark">
+                  Nível de acesso: Vistoriador {{ unidade }}
                 </p>
 
                 <!-- Botão de Visualização 3D -->


### PR DESCRIPTION
## Summary
- Show greeting with logged-in user's name and access level in vistoriador dashboard header
- Improve text visibility for access level message

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'posicoes_suzano')*


------
https://chatgpt.com/codex/tasks/task_e_68920b0ccbb48322918f50c6e5e1590f