### PR TITLE
Show user info in dashboard headers

### DIFF
--- a/templates/auth/dashboard.html
+++ b/templates/auth/dashboard.html
@@ -108,7 +108,11 @@
                 <div class="user-actions">
                   <span class="user-info me-3">
                     <i class="fas fa-user-circle me-1"></i>
-                    Operador
+                    <span class="d-flex flex-column text-end">
+                      <strong>{{ user_role|title }} | {{ unidade }}</strong>
+                      <span>Bem-vindo(a), {{ user.nome if user.nome else user.username }}!</span>
+                      <span class="badge bg-light text-dark">Nível de acesso: {{ user_role|title }} {{ unidade }}</span>
+                    </span>
                   </span>
                   <button class="btn btn-logout" onclick="confirmarLogout()">
                     <i class="fas fa-sign-out-alt me-1"></i>
@@ -121,10 +125,10 @@
             <div class="card-body">
               <!-- Seção de Boas-vindas -->
               <div class="welcome-section">
-                <h4 class="welcome-title">Bem-vindo(a), Operador!</h4>
+                <h4 class="welcome-title">Bem-vindo(a), {{ user.nome if user.nome else user.username }}!</h4>
                 <p class="access-level">
                   Nível de acesso:
-                  <span class="badge bg-secondary">Operador</span>
+                  <span class="badge bg-light text-dark">{{ user_role|title }} {{ unidade }}</span>
                 </p>
               </div>
 

--- a/templates/auth/dashboard_vistoriador.html
+++ b/templates/auth/dashboard_vistoriador.html
@@ -659,10 +659,13 @@
                   Sistema de Pátio
                 </h5>
                 <div class="user-actions">
-                  <span class="user-info me-3">
+                  <span class="user-info me-3 d-flex align-items-center">
                     <i class="fas fa-user-circle me-1"></i>
-                    Bem-vindo(a), {{ user.nome if user.nome else user.username }}!<br />
-                    Nível de acesso: Vistoriador {{ unidade }}
+                    <span class="d-flex flex-column text-end">
+                      <strong>{{ user_role|title }} | {{ unidade }}</strong>
+                      <span>Bem-vindo(a), {{ user.nome if user.nome else user.username }}!</span>
+                      <span class="badge bg-light text-dark">Nível de acesso: {{ user_role|title }} {{ unidade }}</span>
+                    </span>
                   </span>
                   <button class="btn btn-logout" onclick="confirmarLogout()">
                     <i class="fas fa-sign-out-alt me-1"></i>
@@ -679,7 +682,8 @@
                   Bem-vindo(a), {{ user.nome if user.nome else user.username }}!
                 </h4>
                 <p class="mb-3 text-dark">
-                  Nível de acesso: Vistoriador {{ unidade }}
+                  Nível de acesso:
+                  <span class="badge bg-light text-dark">{{ user_role|title }} {{ unidade }}</span>
                 </p>
 
                 <!-- Botão de Visualização 3D -->


### PR DESCRIPTION
## Summary
- display logged user name, role and unit in dashboard headers
- highlight access level with badge for better visibility

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'posicoes_suzano')*


------
https://chatgpt.com/codex/tasks/task_e_68920ce3ca0c832297f92e3a801990a5