### PR TITLE
Improve dashboard user info styling

### DIFF
--- a/static/css/dashboard.css
+++ b/static/css/dashboard.css
@@ -144,12 +144,47 @@ body {
 }
 
 .user-info {
-  color: rgba(255, 255, 255, 0.9);
-  font-size: 0.95rem;
+  color: var(--white-color);
   font-weight: 500;
+  background: rgba(255, 255, 255, 0.1);
+  backdrop-filter: blur(10px);
+  border-radius: var(--border-radius-xl);
+  padding: var(--spacing-md) var(--spacing-lg);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  text-align: right;
+  gap: var(--spacing-xs);
+  min-width: 260px;
+}
+
+.user-role-badge {
+  background: rgba(255, 255, 255, 0.2);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  border-radius: var(--border-radius-full);
+  padding: 0.25rem 0.75rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+}
+
+.user-welcome {
   display: flex;
   align-items: center;
   gap: var(--spacing-xs);
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.user-access {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.85);
 }
 
 .header-logo {

--- a/templates/auth/dashboard.html
+++ b/templates/auth/dashboard.html
@@ -106,14 +106,17 @@
                   Sistema de Pátio
                 </h5>
                 <div class="user-actions">
-                  <span class="user-info me-3">
-                    <i class="fas fa-user-circle me-1"></i>
-                    <span class="d-flex flex-column text-end">
-                      <strong>{{ user_role|title }} | {{ unidade }}</strong>
-                      <span>Bem-vindo(a), {{ user.nome if user.nome else user.username }}!</span>
-                      <span class="badge bg-light text-dark">Nível de acesso: {{ user_role|title }} {{ unidade }}</span>
-                    </span>
-                  </span>
+                  <div class="user-info">
+                    <div class="user-role-badge">
+                      <i class="fas fa-id-badge me-1"></i>{{ user_role|title }} | {{ unidade }}
+                    </div>
+                    <div class="user-welcome">
+                      <i class="fas fa-user-circle me-1"></i>Bem-vindo(a), {{ user.nome if user.nome else user.username }}!
+                    </div>
+                    <div class="user-access">
+                      <i class="fas fa-lock me-1"></i>Nível de acesso: {{ user_role|title }} {{ unidade }}
+                    </div>
+                  </div>
                   <button class="btn btn-logout" onclick="confirmarLogout()">
                     <i class="fas fa-sign-out-alt me-1"></i>
                     Sair

--- a/templates/auth/dashboard_vistoriador.html
+++ b/templates/auth/dashboard_vistoriador.html
@@ -83,27 +83,25 @@
         border-radius: 12px;
         padding: 1rem 1.5rem;
         border: 1px solid rgba(255, 255, 255, 0.2);
-        min-width: 300px;
+        display: flex;
+        flex-direction: column;
+        align-items: flex-end;
+        text-align: right;
+        gap: 0.25rem;
+        min-width: 260px;
       }
 
       .user-welcome {
-        font-size: 1.1rem;
-        font-weight: 600;
-        margin-bottom: 0.5rem;
         display: flex;
         align-items: center;
-        gap: 0.5rem;
+        gap: 0.25rem;
+        font-size: 1rem;
+        font-weight: 600;
       }
 
       .user-welcome i {
         font-size: 1.3rem;
         color: rgba(255, 255, 255, 0.9);
-      }
-
-      .user-details {
-        display: flex;
-        flex-direction: column;
-        gap: 0.3rem;
       }
 
       .user-role-badge {
@@ -113,15 +111,18 @@
         border-radius: 20px;
         font-size: 0.85rem;
         font-weight: 600;
-        display: inline-block;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.25rem;
         border: 1px solid rgba(255, 255, 255, 0.3);
-        width: fit-content;
       }
 
-      .user-unit {
-        font-size: 0.9rem;
+      .user-access {
+        display: flex;
+        align-items: center;
+        gap: 0.25rem;
+        font-size: 0.85rem;
         color: rgba(255, 255, 255, 0.85);
-        font-weight: 500;
       }
 
       .btn-logout {
@@ -370,6 +371,7 @@
         .user-info {
           min-width: auto;
           text-align: center;
+          align-items: center;
         }
 
         .card-header {
@@ -394,9 +396,6 @@
           margin-bottom: 1rem;
         }
 
-        .user-details {
-          align-items: center;
-        }
       }
 
       /* Animações */
@@ -761,20 +760,14 @@
                 </h5>
                 <div class="user-actions">
                   <div class="user-info">
-                    <div class="user-welcome">
-                      <i class="fas fa-user-circle"></i>
-                      <span
-                        >{{ user.nome if user.nome else user.username }}</span
-                      >
+                    <div class="user-role-badge">
+                      <i class="fas fa-id-badge me-1"></i>{{ user_role|title }} | {{ unidade }}
                     </div>
-                    <div class="user-details">
-                      <div class="user-role-badge">
-                        {{ user_role|title }} - {{ unidade }}
-                      </div>
-                      <div class="user-unit">
-                        <i class="fas fa-building me-1"></i>
-                        Unidade: {{ unidade }}
-                      </div>
+                    <div class="user-welcome">
+                      <i class="fas fa-user-circle me-1"></i>Bem-vindo(a), {{ user.nome if user.nome else user.username }}!
+                    </div>
+                    <div class="user-access">
+                      <i class="fas fa-lock me-1"></i>Nível de acesso: {{ user_role|title }} {{ unidade }}
                     </div>
                   </div>
                   <button class="btn btn-logout" onclick="confirmarLogout()">


### PR DESCRIPTION
## Summary
- Restyle dashboard header user info block to display role, welcome message, and access level with icons
- Apply the same user info styling to the Vistoriador dashboard template and adjust responsive layout

## Testing
- `pytest` *(fails: SystemExit: 1 in bkp/test_posicao_validacao.py)*

------
https://chatgpt.com/codex/tasks/task_e_68921a02b3308322b6b60ec4a5eff45f