### PR TITLE
Guard first-login redirect behind session flag

### DIFF
--- a/auth/routes.py
+++ b/auth/routes.py
@@ -260,7 +260,7 @@ def login():
 
             flash(f'Bem-vindo(a), {username}!', 'success')
 
-
+            if session.get('primeiro_login'):
                 flash('Por favor, defina uma nova senha para continuar.', 'warning')
                 return redirect(url_for('auth.primeiro_login'))
 


### PR DESCRIPTION
## Summary
- ensure first-login redirect runs only when needed

## Testing
- `python -m py_compile auth/routes.py`


------
https://chatgpt.com/codex/tasks/task_e_689249f920e8832294b1568faaf35438