### PR TITLE
Guard first-login redirect behind session flag

### DIFF
--- a/auth/routes.py
+++ b/auth/routes.py
@@ -260,7 +260,7 @@ def login():
 
             flash(f'Bem-vindo(a), {username}!', 'success')
 
-
+            if session.get('primeiro_login'):
                 flash('Por favor, defina uma nova senha para continuar.', 'warning')
                 return redirect(url_for('auth.primeiro_login'))
 
@@ -323,14 +323,19 @@ def primeiro_login():
                     (password_hash, datetime.now().strftime('%Y-%m-%d %H:%M:%S'), session.get('user_id'))
                 )
                 conn.commit()
-
-            log_auth_activity(session.get('username'), 'ALTERAR_SENHA', 'Senha definida no primeiro login')
-            session['primeiro_login'] = 0
-            flash('Senha atualizada com sucesso!', 'success')
-            return redirecionar_por_nivel(session.get('nivel'))
         except Exception as e:
             logger.error(f"Erro ao definir nova senha: {e}")
             flash('Erro ao atualizar senha. Tente novamente.', 'danger')
+            return render_template('auth/primeiro_login.html')
+
+        try:
+            log_auth_activity(session.get('username'), 'ALTERAR_SENHA', 'Senha definida no primeiro login')
+        except Exception as e:
+            logger.error(f"Erro ao registrar log de primeiro login: {e}")
+
+        session['primeiro_login'] = 0
+        flash('Senha atualizada com sucesso!', 'success')
+        return redirecionar_por_nivel(session.get('nivel'))
 
     return render_template('auth/primeiro_login.html')
 


### PR DESCRIPTION
## Summary
- ensure first-login redirect runs only when needed
- redirect users to their dashboard once they set a permanent password

## Testing
- `python -m py_compile auth/routes.py`

------
https://chatgpt.com/codex/tasks/task_e_689249f920e8832294b1568faaf35438