### PR TITLE
Ensure login redirects fallback to dashboard

### DIFF
--- a/auth/routes.py
+++ b/auth/routes.py
@@ -265,7 +265,8 @@ def login():
             return redirecionar_por_nivel(user['nivel'])
         except Exception as e:
             logger.error(f"Erro ao redirecionar após login: {e}")
-
+            flash('Erro ao redirecionar após login. Redirecionando para o dashboard padrão.', 'warning')
+            return redirect(url_for('auth.dashboard'))
 
     # Método GET ou erro no fluxo
     return render_template('auth/login.html')


### PR DESCRIPTION
## Summary
- add warning flash and fallback redirect to dashboard when login redirection fails

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'posicoes_suzano')*


------
https://chatgpt.com/codex/tasks/task_e_6892554fd46c83228c695007e264b441