### PR TITLE
feat: display flash messages globally

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -164,6 +164,20 @@
     </style>
 </head>
 <body>
+    <!-- Flash messages -->
+    {% with messages = get_flashed_messages(with_categories=true) %}
+        {% if messages %}
+            <div class="container mt-3">
+                {% for category, message in messages %}
+                    <div class="alert alert-{{ category }} alert-dismissible fade show" role="alert">
+                        {{ message }}
+                        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+                    </div>
+                {% endfor %}
+            </div>
+        {% endif %}
+    {% endwith %}
+
     <!-- Conteúdo da página -->
     {% block content %}{% endblock %}
     


### PR DESCRIPTION
## Summary
- render flash messages in the base template so login errors and other alerts are visible to users

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_689258cf31a88322829edc93738e43a3