### PR TITLE
refactor: enhance user edit page styling

### DIFF
--- a/templates/admin/editar_usuario.html
+++ b/templates/admin/editar_usuario.html
@@ -44,8 +44,8 @@
         <!-- Conteúdo principal -->
         <main class="col-md-9 ms-sm-auto col-lg-10 main-content">
             <!-- Breadcrumb -->
-            <nav aria-label="breadcrumb" class="breadcrumb">
-                <ol class="breadcrumb">
+            <nav aria-label="breadcrumb" class="mb-4">
+                <ol class="breadcrumb bg-light px-3 py-2 rounded">
                     <li class="breadcrumb-item"><a href="{{ url_for('admin.admin_dashboard') }}">Dashboard</a></li>
                     <li class="breadcrumb-item"><a href="{{ url_for('admin.listar_usuarios') }}">Usuários</a></li>
                     <li class="breadcrumb-item active" aria-current="page">Editar Usuário</li>
@@ -53,7 +53,7 @@
             </nav>
 
             <!-- Header da página -->
-            <div class="page-header">
+            <div class="page-header mb-4">
                 <div class="d-flex justify-content-between align-items-center">
                     <h1>
                         <i class="fas fa-user-edit me-2"></i>
@@ -68,28 +68,34 @@
             </div>
 
             <!-- Formulário de edição de usuário -->
-            <div class="admin-card fade-in-up">
-                <div class="card-header">
+            <div class="card admin-card shadow-sm fade-in-up">
+                <div class="card-header bg-primary text-white">
                     <h5 class="mb-0">
                         <i class="fas fa-info-circle me-2"></i>
                         Informações do Usuário
                     </h5>
                 </div>
-                <div class="card-body">
-                    <form method="POST" action="{{ url_for('admin.editar_usuario', usuario_id=usuario.id) }}">
-                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-                        <div class="row">
-                            <div class="col-md-6 mb-3">
+                <form method="POST" action="{{ url_for('admin.editar_usuario', usuario_id=usuario.id) }}">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+                    <div class="card-body">
+                        <div class="row g-3">
+                            <div class="col-md-6">
                                 <label for="username" class="form-label">Nome de Usuário</label>
-                                <input type="text" class="form-control" id="username" value="{{ usuario.username }}" readonly>
+                                <div class="input-group">
+                                    <span class="input-group-text"><i class="fas fa-user"></i></span>
+                                    <input type="text" class="form-control" id="username" value="{{ usuario.username }}" readonly>
+                                </div>
                                 <div class="form-text">
                                     <i class="fas fa-info-circle me-1"></i>
                                     O nome de usuário não pode ser alterado
                                 </div>
                             </div>
-                            <div class="col-md-6 mb-3">
+                            <div class="col-md-6">
                                 <label for="email" class="form-label">Email</label>
-                                <input type="email" class="form-control" id="email" name="email" value="{{ usuario.email }}" required>
+                                <div class="input-group">
+                                    <span class="input-group-text"><i class="fas fa-envelope"></i></span>
+                                    <input type="email" class="form-control" id="email" name="email" value="{{ usuario.email }}" required>
+                                </div>
                                 <div class="form-text">
                                     <i class="fas fa-envelope me-1"></i>
                                     Email válido para contato
@@ -97,54 +103,59 @@
                             </div>
                         </div>
 
-                        <div class="row">
-                            <div class="col-md-6 mb-3">
+                        <div class="row g-3 mt-1">
+                            <div class="col-md-6">
                                 <label for="role" class="form-label">Função</label>
-                                <select class="form-select" id="role" name="role" required>
-                                    <option value="admin" {% if usuario.role == 'admin' %}selected{% endif %}>Administrador</option>
-                                    <option value="operador" {% if usuario.role == 'operador' %}selected{% endif %}>Operador</option>
-                                    <option value="vistoriador" {% if usuario.role == 'vistoriador' %}selected{% endif %}>Vistoriador</option>
-                                    <option value="user" {% if usuario.role == 'user' %}selected{% endif %}>Usuário</option>
-                                </select>
+                                <div class="input-group">
+                                    <span class="input-group-text"><i class="fas fa-user-tag"></i></span>
+                                    <select class="form-select" id="role" name="role" required>
+                                        <option value="admin" {% if usuario.role == 'admin' %}selected{% endif %}>Administrador</option>
+                                        <option value="operador" {% if usuario.role == 'operador' %}selected{% endif %}>Operador</option>
+                                        <option value="vistoriador" {% if usuario.role == 'vistoriador' %}selected{% endif %}>Vistoriador</option>
+                                        <option value="user" {% if usuario.role == 'user' %}selected{% endif %}>Usuário</option>
+                                    </select>
+                                </div>
                             </div>
-                            <div class="col-md-6 mb-3">
+                            <div class="col-md-6">
                                 <label for="unidade" class="form-label">Unidade</label>
-                                <select class="form-select" id="unidade" name="unidade">
-                                    <option value="Rio de Janeiro" {% if usuario.unidade == 'Rio de Janeiro' %}selected{% endif %}>Rio de Janeiro</option>
-                                    <option value="Suzano" {% if usuario.unidade == 'Suzano' or usuario.unidade == 'Floriano' %}selected{% endif %}>Suzano</option>
-                                </select>
+                                <div class="input-group">
+                                    <span class="input-group-text"><i class="fas fa-building"></i></span>
+                                    <select class="form-select" id="unidade" name="unidade">
+                                        <option value="Rio de Janeiro" {% if usuario.unidade == 'Rio de Janeiro' %}selected{% endif %}>Rio de Janeiro</option>
+                                        <option value="Suzano" {% if usuario.unidade == 'Suzano' or usuario.unidade == 'Floriano' %}selected{% endif %}>Suzano</option>
+                                    </select>
+                                </div>
                             </div>
                         </div>
 
-                        <div class="row">
-                            <div class="col-md-6 mb-3">
+                        <div class="row g-3 mt-1">
+                            <div class="col-md-6">
                                 <label for="password" class="form-label">Nova Senha (deixe em branco para manter a atual)</label>
-                                <input type="password" class="form-control" id="password" name="password">
+                                <div class="input-group">
+                                    <span class="input-group-text"><i class="fas fa-lock"></i></span>
+                                    <input type="password" class="form-control" id="password" name="password">
+                                </div>
                                 <div class="form-text">
                                     <i class="fas fa-lock me-1"></i>
                                     Preencha apenas se desejar alterar a senha
                                 </div>
                             </div>
                         </div>
-                        
+
                         <!-- Requisitos de senha -->
-                        <div class="row">
-                            <div class="col-md-12 mb-3">
-                                <div class="alert alert-info">
-                                    <h6><i class="fas fa-key me-2"></i>Requisitos de Senha:</h6>
-                                    <ul class="mb-0">
-                                        <li>Mínimo de 8 caracteres</li>
-                                        <li>Pelo menos uma letra maiúscula</li>
-                                        <li>Pelo menos uma letra minúscula</li>
-                                        <li>Pelo menos um número</li>
-                                        <li>Pelo menos um caractere especial (!@#$%^&*)</li>
-                                    </ul>
-                                </div>
-                            </div>
+                        <div class="alert alert-info mb-4 mt-3">
+                            <h6><i class="fas fa-key me-2"></i>Requisitos de Senha:</h6>
+                            <ul class="mb-0">
+                                <li>Mínimo de 8 caracteres</li>
+                                <li>Pelo menos uma letra maiúscula</li>
+                                <li>Pelo menos uma letra minúscula</li>
+                                <li>Pelo menos um número</li>
+                                <li>Pelo menos um caractere especial (!@#$%^&*)</li>
+                            </ul>
                         </div>
 
                         <!-- Informações de sistema -->
-                        <div class="row mb-3">
+                        <div class="row g-3 mb-3">
                             <div class="col-md-6">
                                 <label class="form-label">Data de Criação</label>
                                 <input type="text" class="form-control" value="{{ usuario.created_at }}" readonly>
@@ -154,18 +165,16 @@
                                 <input type="text" class="form-control" value="{{ usuario.last_login if usuario.last_login else 'Nunca' }}" readonly>
                             </div>
                         </div>
-                        
-                        <!-- Botões de ação -->
-                        <div class="d-flex justify-content-end">
-                            <a href="{{ url_for('admin.listar_usuarios') }}" class="btn btn-outline-secondary me-2">
-                                <i class="fas fa-times me-2"></i>Cancelar
-                            </a>
-                            <button type="submit" class="btn btn-primary">
-                                <i class="fas fa-save me-2"></i>Salvar Alterações
-                            </button>
-                        </div>
-                    </form>
-                </div>
+                    </div>
+                    <div class="card-footer text-end">
+                        <a href="{{ url_for('admin.listar_usuarios') }}" class="btn btn-outline-secondary me-2">
+                            <i class="fas fa-times me-2"></i>Cancelar
+                        </a>
+                        <button type="submit" class="btn btn-primary">
+                            <i class="fas fa-save me-2"></i>Salvar Alterações
+                        </button>
+                    </div>
+                </form>
             </div>
         </main>
     </div>


### PR DESCRIPTION
## Summary
- polish breadcrumb with rounded styling
- overhaul edit user form layout with Bootstrap cards and input icons
- add card footer with aligned action buttons

## Testing
- `pytest` *(fails: SystemExit in bkp/test_posicao_validacao.py)*

------
https://chatgpt.com/codex/tasks/task_e_689258cf31a88322829edc93738e43a3